### PR TITLE
Fix tests

### DIFF
--- a/androidsdk/build.gradle
+++ b/androidsdk/build.gradle
@@ -21,6 +21,10 @@ android {
     packagingOptions {
         exclude 'LICENSE.txt'
     }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 allprojects {

--- a/androidsdk/src/test/java/com/wootric/androidsdk/SurveyValidatorTest.java
+++ b/androidsdk/src/test/java/com/wootric/androidsdk/SurveyValidatorTest.java
@@ -63,6 +63,8 @@ public class SurveyValidatorTest {
     public void doesNotCheckEligibility_whenRecentlySurveyed() throws Exception {
         User user = testUser();
         EndUser endUser = testEndUser();
+        long createdAtJustNow = new Date().getTime();
+        endUser.setCreatedAt(createdAtJustNow);
         Settings settings = new Settings();
 
         doReturn(true).when(preferencesUtils).wasRecentlySurveyed();


### PR DESCRIPTION
-Adds returnDefaultValues in gradle for Log class to work
-Fixs doesNotCheckEligibility_whenRecentlySurveyed test

More info on `unitTests.returnDefaultValues = true`:
http://tools.android.com/tech-docs/unit-testing-support#TOC-Method-...-not-mocked.-

> We are aware that the default behavior is problematic when using classes like Log or TextUtils and will evaluate possible solutions in future releases.
