### PR TITLE
Fix User-Agent header

### DIFF
--- a/androidsdk/src/main/java/com/wootric/androidsdk/network/tasks/WootricRemoteRequestTask.java
+++ b/androidsdk/src/main/java/com/wootric/androidsdk/network/tasks/WootricRemoteRequestTask.java
@@ -78,7 +78,7 @@ public abstract class WootricRemoteRequestTask extends AsyncTask<Void, Void, Str
             URL url = new URL(urlWithParams);
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod(requestType);
-            conn.setRequestProperty("HTTP_USER_AGENT", HTTP_AGENT);
+            conn.setRequestProperty("User-Agent", HTTP_AGENT);
 
             if(accessToken != null) {
                 conn.setRequestProperty("Authorization", "Bearer " + accessToken);


### PR DESCRIPTION
Fix the User-Agent header field. When checking eligibility
this is very important if the user has the Mobile Switch
disabled on the Dashboard settings.