### PR TITLE
Check activity is not null

### DIFF
--- a/androidsdk/src/main/java/com/wootric/androidsdk/SurveyManager.java
+++ b/androidsdk/src/main/java/com/wootric/androidsdk/SurveyManager.java
@@ -42,7 +42,7 @@ import com.wootric.androidsdk.views.SurveyFragment;
  */
 public class SurveyManager implements SurveyValidator.OnSurveyValidatedListener, WootricApiCallback {
 
-    private static final String LOG_TAG = SurveyManager.class.getName();
+    private static final String LOG_TAG = "WOOTRIC_SDK";
 
     private final Activity activity;
     private final WootricRemoteClient wootricApiClient;
@@ -197,14 +197,15 @@ public class SurveyManager implements SurveyValidator.OnSurveyValidatedListener,
 
     private String getOriginUrl() {
         if(originUrl == null) {
-            PackageManager pm = activity.getPackageManager();
+            PackageManager pm;
             ApplicationInfo appInfo;
 
             try {
+                pm = activity.getPackageManager();
                 appInfo = pm.getApplicationInfo(activity.getApplicationInfo().packageName, 0);
                 originUrl = pm.getApplicationLabel(appInfo).toString();
-            }
-            catch (Exception e) {
+            } catch (Exception e) {
+                Log.e(LOG_TAG, e.getLocalizedMessage());
             }
         }
 

--- a/androidsdk/src/main/java/com/wootric/androidsdk/utils/ScreenUtils.java
+++ b/androidsdk/src/main/java/com/wootric/androidsdk/utils/ScreenUtils.java
@@ -39,7 +39,7 @@ public class ScreenUtils {
     private static int screenWidth = 0;
 
     public static int getScreenHeight(Context c) {
-        if (screenHeight == 0) {
+        if (c != null && screenHeight == 0) {
             WindowManager wm = (WindowManager) c.getSystemService(Context.WINDOW_SERVICE);
             Display display = wm.getDefaultDisplay();
             Point size = new Point();
@@ -51,7 +51,7 @@ public class ScreenUtils {
     }
 
     public static int getScreenWidth(Context c) {
-        if (screenWidth == 0) {
+        if (c != null && screenWidth == 0) {
             WindowManager wm = (WindowManager) c.getSystemService(Context.WINDOW_SERVICE);
             Display display = wm.getDefaultDisplay();
             Point size = new Point();

--- a/androidsdk/src/main/java/com/wootric/androidsdk/utils/SocialHandler.java
+++ b/androidsdk/src/main/java/com/wootric/androidsdk/utils/SocialHandler.java
@@ -27,6 +27,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.util.Log;
 
 import java.util.List;
 
@@ -35,6 +36,8 @@ import java.util.List;
  */
 public class SocialHandler {
 
+    private static final String LOG_TAG = "WOOTRIC_SDK";
+
     private final Context mContext;
 
     public SocialHandler(Context mContext) {
@@ -42,6 +45,8 @@ public class SocialHandler {
     }
 
     public void shareOnFacebook(String facebookId) {
+        if (mContext == null) return;
+
         String urlToShare = "https://www.facebook.com/" + facebookId;
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType("text/plain");
@@ -66,6 +71,8 @@ public class SocialHandler {
     }
 
     public void goToFacebook(String facebookId) {
+        if (mContext == null) return;
+
         final String url = "https://www.facebook.com/" + facebookId;
         final Uri facebookSchemeUri = Uri.parse("fb://facewebmodal/f?href=" + url);
         Intent intent = new Intent(Intent.ACTION_VIEW, facebookSchemeUri);
@@ -88,6 +95,8 @@ public class SocialHandler {
     }
 
     public void goToTwitter(String twitterPage, String text) {
+        if (mContext == null) return;
+
         final Intent twitterIntent = new Intent(Intent.ACTION_SEND);
         final String tweetContent = "@" + twitterPage + " " + text;
 
@@ -112,7 +121,7 @@ public class SocialHandler {
 
         if(resolved){
             mContext.startActivity(twitterIntent);
-        }else{
+        } else {
             final Intent browserTweeter = new Intent(Intent.ACTION_VIEW);
             final Uri tweetUri = Uri.parse("https://twitter.com/intent/tweet?text=" + tweetContent);
             browserTweeter.setData(tweetUri);

--- a/androidsdk/src/main/java/com/wootric/androidsdk/views/SurveyFragment.java
+++ b/androidsdk/src/main/java/com/wootric/androidsdk/views/SurveyFragment.java
@@ -152,6 +152,7 @@ public class SurveyFragment extends DialogFragment
 
     private void measurePhoneDialog() {
         final Activity activity = getActivity();
+        if (activity == null) return;
 
         Dialog dialog = getDialog();
         if (dialog == null) return;
@@ -285,7 +286,10 @@ public class SurveyFragment extends DialogFragment
     public void onShouldShowSimpleDialog() {
         final Activity activity = getActivity();
 
-        ThankYouDialogFactory.create(activity, mSettings, mSurveyLayout.getSelectedScore()).show();
+        if (activity != null) {
+            ThankYouDialogFactory.create(activity, mSettings, mSurveyLayout.getSelectedScore()).show();
+        }
+
         dismiss();
     }
 


### PR DESCRIPTION
So Practo's crashes logs are this:
`Fatal Exception: android.view.WindowManager$BadTokenException: Unable to add window -- token android.os.BinderProxy@769aebf is not valid; is your activity running?`

and

`Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.pm.PackageManager android.app.Activity.getPackageManager()' on a null object reference`

I checked a lot and searched over the internet
and this has to do with the context being destroyed
before the survey completes the process and shows
up. I couldn't replicate because this is very hard
to replicate.

Here's an explanation I found on StackOverflow:

This can occur when you are showing the dialog for
a context that no longer exists. A common case -
if the 'show dialog' operation is after an
asynchronous operation, and during that operation
the original activity (that is to be the parent of
your dialog) is destroyed.

http://stackoverflow.com/questions/9529504/unable-to-add-window-token-android-os-binderproxy-is-not-valid-is-your-activ

Full logs:
```
Fatal Exception: android.view.WindowManager$BadTokenException: Unable to add window -- token android.os.BinderProxy@769aebf is not valid; is your activity running?
       at android.view.ViewRootImpl.setView(ViewRootImpl.java:579)
       at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:310)
       at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:85)
       at android.app.Dialog.show(Dialog.java:319)
       at android.app.DialogFragment.onStart(DialogFragment.java:502)
       at com.wootric.androidsdk.views.SurveyFragment.onStart(SurveyFragment.java:109)
       at android.app.Fragment.performStart(Fragment.java:2244)
       at android.app.FragmentManagerImpl.moveToState(FragmentManager.java:1002)
       at android.app.FragmentManagerImpl.moveToState(FragmentManager.java:1148)
       at android.app.BackStackRecord.run(BackStackRecord.java:793)
       at android.app.FragmentManagerImpl.execPendingActions(FragmentManager.java:1537)
       at android.app.FragmentManagerImpl$1.run(FragmentManager.java:482)
       at android.os.Handler.handleCallback(Handler.java:746)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:148)
       at android.app.ActivityThread.main(ActivityThread.java:5443)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:728)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:618)
```
```
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.pm.PackageManager android.app.Activity.getPackageManager()' on a null object reference
       at com.wootric.androidsdk.SurveyManager.getOriginUrl(SurveyManager.java:178)
       at com.wootric.androidsdk.SurveyManager.sendGetTrackingPixelRequest(SurveyManager.java:121)
       at com.wootric.androidsdk.SurveyManager.start(SurveyManager.java:52)
       at com.wootric.androidsdk.Wootric.survey(Wootric.java:154)
       at com.practo.droid.ray.home.RayHomeActivity.processWootricSurvey(RayHomeActivity.java:223)
       at com.practo.droid.ray.home.RayHomeActivity.onCreate(RayHomeActivity.java:162)
       at android.app.Activity.performCreate(Activity.java:6285)
       at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1118)
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2405)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2535)
       at android.app.ActivityThread.access$900(ActivityThread.java:154)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1380)
       at android.os.Handler.dispatchMessage(Handler.java:102)
       at android.os.Looper.loop(Looper.java:152)
       at android.app.ActivityThread.main(ActivityThread.java:5497)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```