### PR TITLE
Don't use hard-coded English text

### DIFF
--- a/androidsdk/src/main/java/com/wootric/androidsdk/views/phone/ThankYouDialogFactory.java
+++ b/androidsdk/src/main/java/com/wootric/androidsdk/views/phone/ThankYouDialogFactory.java
@@ -27,6 +27,7 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 
+import com.wootric.androidsdk.R;
 import com.wootric.androidsdk.objects.Settings;
 
 /**
@@ -45,7 +46,7 @@ public class ThankYouDialogFactory {
             thankYouDialog.setMessage(thankYouText);
         }
 
-        thankYouDialog.setButton(AlertDialog.BUTTON_NEGATIVE, "DONE", new DialogInterface.OnClickListener() {
+        thankYouDialog.setButton(AlertDialog.BUTTON_NEGATIVE, context.getString(R.string.wootric_done), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 dialog.dismiss();

--- a/androidsdk/src/main/res/values/strings.xml
+++ b/androidsdk/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="tv_twitter">Share on Twitter</string>
     <string name="no_thanks">No thanks…</string>
     <string name="x">X</string>
+    <string name="wootric_done">DONE</string>
 </resources>


### PR DESCRIPTION
This change at least makes it possible to localize the Thank you dialog button to a language other than English.