### PR TITLE
added translation for 'opt out' and forced rating bar to ltr

### DIFF
--- a/androidsdk/src/main/res/layout/wootric_survey_layout.xml
+++ b/androidsdk/src/main/res/layout/wootric_survey_layout.xml
@@ -88,6 +88,7 @@
                     android:layout_marginStart="@dimen/wootric_rating_bar_layout_margin_start"
                     android:layout_marginTop="@dimen/wootric_rating_bar_layout_margin_top"
                     android:gravity="center"
+                    android:layoutDirection="ltr"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"

--- a/androidsdk/src/main/res/values-ar/strings.xml
+++ b/androidsdk/src/main/res/values-ar/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="wootric_opt_out">إلغاء</string>
+</resources>


### PR DESCRIPTION
Translation of opt-out is added and rating bar is forced to LTR, as its standard and inconvenient when RTLed. 