### PR TITLE
Add skipFreedbackScreen

### DIFF
--- a/androidsdk/src/main/java/com/wootric/androidsdk/Wootric.java
+++ b/androidsdk/src/main/java/com/wootric/androidsdk/Wootric.java
@@ -398,7 +398,16 @@ public class Wootric {
     }
 
     /**
-     *
+      * Setter to skip feedback screen and go to thank you message.
+      * @param skipFeedbackScreen boolean value.
+      */
+    public void skipFeedbackScreen(boolean skipFeedbackScreen) {
+        settings.setSkipFeedbackScreen(skipFeedbackScreen);
+    }
+
+    /**
+     * Set Survey Type Scale
+     * @param surveyTypeScale typeScale int
      */
     public void setSurveyTypeScale(int surveyTypeScale) {
         settings.setCustomSurveyTypeScale(surveyTypeScale);

--- a/androidsdk/src/main/java/com/wootric/androidsdk/objects/Settings.java
+++ b/androidsdk/src/main/java/com/wootric/androidsdk/objects/Settings.java
@@ -54,6 +54,7 @@ public class Settings implements Parcelable {
     private boolean surveyImmediately;
     private boolean showOptOut;
     private boolean skipFollowupScreenForPromoters;
+    private boolean skipFeedbackScreen;
 
     private Integer dailyResponseCap;
     private Integer registeredPercent;
@@ -128,6 +129,12 @@ public class Settings implements Parcelable {
     public boolean shouldSkipFollowupScreenForPromoters() {
         return skipFollowupScreenForPromoters;
     }
+
+    public void setSkipFeedbackScreen(boolean skipFeedbackScreen) {
+        this.skipFeedbackScreen = skipFeedbackScreen;
+    }
+
+    public boolean skipFeedbackScreen() { return skipFeedbackScreen; }
 
     public int getTimeDelayInMillis() {
         int time;

--- a/androidsdk/src/main/java/com/wootric/androidsdk/views/phone/SurveyLayoutPhone.java
+++ b/androidsdk/src/main/java/com/wootric/androidsdk/views/phone/SurveyLayoutPhone.java
@@ -263,9 +263,8 @@ public class SurveyLayoutPhone extends LinearLayout
         notifyListener();
 
         Score score = new Score(mRatingBar.getSelectedScore(), mSettings.getSurveyType(), mSettings.getSurveyTypeScale());
-        boolean shouldSkipFeedbackScreen = score.isPromoter() &&
-                mSettings.shouldSkipFollowupScreenForPromoters();
-
+        boolean shouldSkipFeedbackScreen = mSettings.skipFeedbackScreen() ||
+                (score.isPromoter() && mSettings.shouldSkipFollowupScreenForPromoters());
 
         if(isFeedbackState() || shouldSkipFeedbackScreen) {
             updateState(STATE_THANK_YOU);

--- a/androidsdk/src/main/java/com/wootric/androidsdk/views/tablet/SurveyLayoutTablet.java
+++ b/androidsdk/src/main/java/com/wootric/androidsdk/views/tablet/SurveyLayoutTablet.java
@@ -398,8 +398,8 @@ public class SurveyLayoutTablet extends LinearLayout
         mCurrentScore = scoreValue;
 
         Score score = new Score(mCurrentScore, mSettings.getSurveyType(), mSettings.getSurveyTypeScale());
-        boolean shouldSkipFeedbackScreen = score.isPromoter() &&
-                mSettings.shouldSkipFollowupScreenForPromoters();
+        boolean shouldSkipFeedbackScreen = mSettings.skipFeedbackScreen() ||
+                (score.isPromoter() && mSettings.shouldSkipFollowupScreenForPromoters());
 
         if(mCurrentScore != Constants.NOT_SET) {
             if(shouldSkipFeedbackScreen) {

--- a/androidsdk/src/test/java/com/wootric/androidsdk/WootricTest.java
+++ b/androidsdk/src/test/java/com/wootric/androidsdk/WootricTest.java
@@ -386,4 +386,13 @@ public class WootricTest {
         assertThat(Wootric.singleton).isNull();
         verify(wootric.preferencesUtils, never()).touchLastSurveyed(false, 0);
     }
+
+    @Test
+    public void whenSkipFeedbackScreenTrue_doesNotShowFeedbackScreen() {
+        Wootric.singleton = null;
+        Wootric wootric = spy(Wootric.init(TEST_FRAGMENT_ACTIVITY, CLIENT_ID, CLIENT_SECRET, ACCOUNT_TOKEN));
+        Wootric wootric_1 = spy(Wootric.init(TEST_FRAGMENT_ACTIVITY, CLIENT_ID, ACCOUNT_TOKEN));
+        wootric.skipFeedbackScreen(true);
+        wootric_1.skipFeedbackScreen(true);
+    }
 }


### PR DESCRIPTION
## Changes

- Add skipFeedbackScreen method
- Add test

## Test

1. Set `wootric.skipFeedbackScreen(true);`
2. Feedback screen should be skipped regardless of the score.
3. Test on both smartphones and tablets

## Trello (internal reference)

https://trello.com/c/E7AH0VmZ/5195-android-sdk-add-skipfeedbackscreen-method