### PR TITLE
Fix SurveyFragment memory leak.

### DIFF
--- a/androidsdk/src/main/java/com/wootric/androidsdk/SurveyManager.java
+++ b/androidsdk/src/main/java/com/wootric/androidsdk/SurveyManager.java
@@ -27,6 +27,7 @@ import android.app.Activity;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.os.Handler;
+import android.util.Log;
 
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -34,8 +35,6 @@ import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleObserver;
 import androidx.lifecycle.OnLifecycleEvent;
 import androidx.lifecycle.ProcessLifecycleOwner;
-
-import android.util.Log;
 
 import com.wootric.androidsdk.network.WootricApiCallback;
 import com.wootric.androidsdk.network.WootricRemoteClient;
@@ -319,7 +318,7 @@ public class SurveyManager implements SurveyValidator.OnSurveyValidatedListener,
                     fragmentActivityManager.beginTransaction()
                             .add(android.R.id.content, surveySupportFragment, SURVEY_DIALOG_TAG)
                             .setCustomAnimations(R.anim.slide_up_dialog, R.anim.slide_down_dialog)
-                            .addToBackStack(null).commit();
+                            .commit();
                 } else {
                     surveySupportFragment.show(fragmentActivityManager, SURVEY_DIALOG_TAG);
                 }
@@ -338,7 +337,7 @@ public class SurveyManager implements SurveyValidator.OnSurveyValidatedListener,
                     fragmentManager.beginTransaction()
                             .add(android.R.id.content, surveyFragment, SURVEY_DIALOG_TAG)
                             .setCustomAnimations(R.anim.slide_up_dialog, R.anim.slide_down_dialog)
-                            .addToBackStack(null).commit();
+                            .commit();
                 } else {
                     surveyFragment.show(fragmentManager, SURVEY_DIALOG_TAG);
                 }
@@ -397,5 +396,11 @@ public class SurveyManager implements SurveyValidator.OnSurveyValidatedListener,
     @Override
     public void onSurveyFinished() {
         this.surveyRunning = false;
+        if (this.surveyFragment != null) {
+            this.surveyFragment = null;
+        }
+        if (this.surveySupportFragment != null) {
+            this.surveySupportFragment = null;
+        }
     }
 }

--- a/androidsdk/src/main/java/com/wootric/androidsdk/views/SurveyFragment.java
+++ b/androidsdk/src/main/java/com/wootric/androidsdk/views/SurveyFragment.java
@@ -24,13 +24,13 @@ package com.wootric.androidsdk.views;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.app.DialogFragment;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
-import android.app.DialogFragment;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -348,16 +348,11 @@ public class SurveyFragment extends DialogFragment
         if (mSurveyCallback != null) {
             mSurveyCallback.onSurveyWillHide();
         }
-
-        if (mIsTablet) {
-            this.onDestroy();
-        }
     }
 
     @Override
     public void onDestroy() {
         super.onDestroy();
-
         isResumedOnConfigurationChange = true;
 
         if (!mShouldShowSimpleDialog) {

--- a/androidsdk/src/main/java/com/wootric/androidsdk/views/support/SurveyFragment.java
+++ b/androidsdk/src/main/java/com/wootric/androidsdk/views/support/SurveyFragment.java
@@ -30,7 +30,6 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
-import androidx.fragment.app.DialogFragment;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -39,6 +38,8 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+
+import androidx.fragment.app.DialogFragment;
 
 import com.wootric.androidsdk.OfflineDataHandler;
 import com.wootric.androidsdk.R;
@@ -349,15 +350,11 @@ public class SurveyFragment extends DialogFragment implements SurveyLayoutListen
         if (mSurveyCallback != null) {
             mSurveyCallback.onSurveyWillHide();
         }
-        if (mIsTablet) {
-            this.onDestroy();
-        }
     }
 
     @Override
     public void onDestroy() {
         super.onDestroy();
-
         isResumedOnConfigurationChange = true;
 
         if (!mShouldShowSimpleDialog) {


### PR DESCRIPTION
Hello there 👋 

We are using the Wootric SDK in some of our Android apps at [Deliveroo](https://deliveroo.co.uk/). We have the [Leak Canary library](https://square.github.io/leakcanary/) set up in our apps, and it reported a memory leak in your SDK. More precisely, the `SurveyFragment` is leaking after being closed, wether it is after successfully completing a survey or simply by closing it at any time using the close button. This happens on both mobile & tablet.

I managed to reproduce the leak in your sample app by setting up the Leak Canary SDK in the sample code, getting the survey displayed and closing it. Feel free to [set it up](https://square.github.io/leakcanary/getting_started/) by yourself to fully observe it. Otherwise, you can view the heap analysis results in the following gist: [link](https://gist.github.com/Yannshu/bc71159967d26a34168ce757e95a8735).

### Changes
There are basically 2 parts to this fix:
1. Stop adding the `SurveyFragment` instance to the backstack before displaying it (removed the call to `addToBackStack(null)` before committing the fragment transaction). If a fragment is added to the backstack, it needs to be removed from the backstack when dismissed in order to get properly destroyed. This wasn't done in the codebase and was preventing the `SurveyFragment` to be properly destroyed on tablets. With the change, `onDestroy()` gets called from the fragment lifecycle and this removes the need of manually calling `onDestroy()` from `onPause()` in `SurveyFragment`.
1. Reset the `surveyFragment` or `surveySupportFragment` instances to `null` in `SurveyManager` when the survey is finished. Holding a hard reference to the fragment was preventing it to be garbage collected properly.

### How to test it
1. Before applying the changes, [set up](https://square.github.io/leakcanary/getting_started/) the Canary Leak library in your sample app. Get the survey displayed and close it. This will trigger the leak. Then, you can click on the Canary Leak notification to dump the heap & analyse the leak.
1. Apply the patch and reproduce the same procedure. After closing the survey, you'll no longer the Canary Leak notification, the `SurveyFragment` is no longer leaking 🎉 

I'm obviously not the most familiar person with this codebase, I just cloned it last night and attempted to fix this behaviour. While all the unit tests still pass, I would advise to fully test the different behaviours of the survey before publishing a new version with this change, to make sure it did not create any regression.