### PR TITLE
Fix activity related leaks.

### DIFF
--- a/androidsdk/src/main/java/com/wootric/androidsdk/SurveyManager.java
+++ b/androidsdk/src/main/java/com/wootric/androidsdk/SurveyManager.java
@@ -94,6 +94,7 @@ public class SurveyManager implements SurveyValidator.OnSurveyValidatedListener,
         handler.removeCallbacks(surveyRunner);
 
         surveyRunning = false;
+        currentEvent = null;
 
         if (surveySupportFragment != null) {
             surveySupportFragment.dismiss();
@@ -168,7 +169,8 @@ public class SurveyManager implements SurveyValidator.OnSurveyValidatedListener,
                                 surveyValidator.validate();
                             } else {
                                 Log.e(Constants.TAG, "Event name not registered: " + currentEvent.getSettings().getEventName());
-                                this.surveyRunning = false;
+                                surveyRunning = false;
+                                currentEvent = null;
                                 runSurvey();
                             }
                         }
@@ -189,7 +191,8 @@ public class SurveyManager implements SurveyValidator.OnSurveyValidatedListener,
     @Override
     public void onSurveyNotNeeded() {
         Wootric.notifySurveyFinished(false, false, 0);
-        this.surveyRunning = false;
+        surveyRunning = false;
+        currentEvent = null;
         runSurvey();
     }
 
@@ -197,7 +200,8 @@ public class SurveyManager implements SurveyValidator.OnSurveyValidatedListener,
     public void onRegisteredEvents(ArrayList<String> registeredEvents) {
         this.registeredEvents = registeredEvents;
         if (currentEvent == null) {
-            this.surveyRunning = false;
+            surveyRunning = false;
+            currentEvent = null;
             runSurvey();
         } else {
             if (!currentEvent.getSettings().getEventName().isEmpty()) {
@@ -205,7 +209,8 @@ public class SurveyManager implements SurveyValidator.OnSurveyValidatedListener,
                     surveyValidator.validate();
                 } else {
                     Log.e(Constants.TAG, "Event name not registered: " + currentEvent.getSettings().getEventName());
-                    this.surveyRunning = false;
+                    surveyRunning = false;
+                    currentEvent = null;
                     runSurvey();
                 }
             } else {
@@ -218,7 +223,8 @@ public class SurveyManager implements SurveyValidator.OnSurveyValidatedListener,
     public void onAuthenticateSuccess(String accessToken) {
         if(accessToken == null) {
             Wootric.notifySurveyFinished(false, false, 0);
-            this.surveyRunning = false;
+            surveyRunning = false;
+            currentEvent = null;
             return;
         }
 
@@ -260,7 +266,8 @@ public class SurveyManager implements SurveyValidator.OnSurveyValidatedListener,
     public void onApiError(Exception error) {
         Log.e(Constants.TAG, "API error: " + error);
         Wootric.notifySurveyFinished(false, false, 0);
-        this.surveyRunning = false;
+        surveyRunning = false;
+        currentEvent = null;
     }
 
     private void sendGetAccessTokenRequest() {
@@ -391,6 +398,7 @@ public class SurveyManager implements SurveyValidator.OnSurveyValidatedListener,
 
     @Override
     public void onSurveyFinished() {
-        this.surveyRunning = false;
+        surveyRunning = false;
+        currentEvent = null;
     }
 }


### PR DESCRIPTION
Hello again 👋 

Had a bit of time this afternoon, so I investigated and solved the leak reported by @astamato in issue https://github.com/Wootric/WootricSDK-Android/issues/97. This leak is can be easily spotted by Leak Canary and reproduced by displaying the survey in one activity, closing the survey, then finishing this activity and opening another one. You can view the heap analysis result in the following gist: [link](https://gist.github.com/Yannshu/a7206d558e535a3c223950cb967d7dab).

This PR fixes 2 different leaks related to holding hard references to activity objects. It will be easier to review it commit per commit.

### Changes:
1. Stop keeping a hard reference to activities related object in `SurveyManager`. Looking at the code structure, this isn't needed. This was causing a memory leak when navigating to another activity, as the hard references were preventing the previous activity to be garbage collected.
2. Set `FragmentManager.currentEvent` attribute to `null` when the survey is finished (or doesn't load). The `CurrentEvent` class holds hard references to activity objects, and as for 1., when navigating to another activity, these references were preventing the previous activity to be garbage collected.

### How to test it:
#### To observe the memory leak:
1. On a branch starting from master (not from this PR's branch), apply [this patch](https://gist.github.com/Yannshu/809c8dc0e6fc94793f4048b6de256675) in your repo. To do so, download the gist to a file and use the following git command in your repo: `git am -3 -k spot-leak-setup.patch`.
1. Compile the app, launch it, get the survey displayed, close it, and press the new **Navigate to another activity** button added by the patch.
1. If this is tested before merging my other [PR](https://github.com/Wootric/WootricSDK-Android/pull/96), Leak Canary will report 3 leaks. 1 fixed by that previous PR, and this PR is fixing the other 2.

#### To test this PR
1. Checkout changes from this PR.
1. Apply that same patch again.
1. Compile the app, launch it, get the survey displayed, close it, and press the new **Navigate to another activity** button added by the patch.
1. Leak Canary will no longer report 3 leaks. If this is tested before merging my other [PR](https://github.com/Wootric/WootricSDK-Android/pull/96), it will still report one though. Nothing to worry about, it'll get fixed when merging the other one.
1. Make sure only this branch gets merged into master, I don't think my patch to spot the leak should be added to the repo.

Same thing than for my other [PR](https://github.com/Wootric/WootricSDK-Android/pull/96). I'm obviously not the most familiar person with this codebase, I just spent a bit of time fixing these memory leaks. While all the unit tests still pass, I would advise to fully test the different behaviours of the survey before publishing a new version with this change, to make sure it did not create any regression.