### PR TITLE
Move currentEvent.getActivity() inside try/catch.

### DIFF
--- a/androidsdk/src/main/java/com/wootric/androidsdk/SurveyManager.java
+++ b/androidsdk/src/main/java/com/wootric/androidsdk/SurveyManager.java
@@ -299,9 +299,9 @@ public class SurveyManager implements SurveyValidator.OnSurveyValidatedListener,
 
     @SuppressLint("ResourceType")
     private void showSurveyFragment() {
-        Activity activity = currentEvent.getActivity();
-        FragmentActivity fragmentActivity = currentEvent.getFragmentActivity();
         try {
+            Activity activity = currentEvent.getActivity();
+            FragmentActivity fragmentActivity = currentEvent.getFragmentActivity();
             if (fragmentActivity != null) {
                 FragmentManager fragmentActivityManager = fragmentActivity.getSupportFragmentManager();
 


### PR DESCRIPTION
A quick and dirty fix to patch the crash reported in https://github.com/Wootric/WootricSDK-Android/issues/103.

### Changes
I moved these 2 lines:
```
Activity activity = currentEvent.getActivity();
FragmentActivity fragmentActivity = currentEvent.getFragmentActivity();
```
inside the `try { ... } catch (NullPointerException e) { ... }` block. So if `currentEvent` is null when `showSurveyFragment()` is called, the exception will be caught and won't cause the app to crash.
It's definitely not the most elegant way to fix this problem, but the most convenient one for the time being.

### How to test it
As I'm unsure how this can happen in real conditions due to the lack of explanations in https://github.com/Wootric/WootricSDK-Android/issues/103, I've tested this by manually setting `currentEvent` to `null` before `showSurveyFragment()` is called. The `NullPointerException` was caught, as expected.

I've also run the unit test suite, all the tests are passing, as expected.

### Final word
If a proper fix for https://github.com/Wootric/WootricSDK-Android/issues/103 is going to take some time, would it be possible to merge this and quickly release a library update with this patch, to give us a bit more confidence that the crash experienced on the 21st of February won't happen again?