### PR TITLE
Set text color of thank you message

### DIFF
--- a/androidsdk/src/main/res/layout/wootric_thank_you_layout.xml
+++ b/androidsdk/src/main/res/layout/wootric_thank_you_layout.xml
@@ -25,7 +25,8 @@
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:fontFamily="@font/ibmplexsans"
-        android:textSize="@dimen/wootric_social_text_size" />
+        android:textSize="@dimen/wootric_social_text_size"
+        android:textColor="@android:color/black" />
 
     <LinearLayout
         android:id="@+id/wootric_layout_facebook_like"


### PR DESCRIPTION
While implementing the Wootric Android SDK in our Android app, I noticed an issue with the thank you message: on one phone it showed up fine, but on another, it didn't seem to show up at all. After some testing, I pinned it down to the dark theme: when dark theme is enabled in Android settings, the text disappears. As it turns out the text is actually there - it's just white, on a white background.

To resolve the issue, I explicitly set the text color of the affected element in the layout, just like the other text elements.